### PR TITLE
Use Gregorian dates across project

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "get-stream": "^9.0.1",
-    "jalali-moment": "^3.3.11",
-    "moment-jalaali": "^0.10.4",
     "moment-timezone": "^0.6.0",
     "node-cron": "^3.0.0",
     "node-telegram-bot-api": "^0.66.0",

--- a/public/app.js
+++ b/public/app.js
@@ -424,7 +424,7 @@ document.addEventListener('DOMContentLoaded', function() {
             goToSettings() { renderSettings(userData); },
             goToAnalysis() { renderAnalysis(userData, charts); },
             goToDashboard() { renderDashboard(userData); },
-            changeMonth(direction) { calendarDate.add(direction, 'jMonth'); this.renderCalendar(calendarDate); },
+            changeMonth(direction) { calendarDate.add(direction, 'month'); this.renderCalendar(calendarDate); },
             renderCalendar(date) { calendarDate = date; renderCalendar(calendarDate, userData); },
             logToday() { const todayStr = moment().format('YYYY-MM-DD'); this.openLogModal(todayStr); },
             goToToday() {
@@ -444,7 +444,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 selectedLogDate = dateKey;
                 const currentLog = userData.logs[selectedLogDate] || {};
                 const shouldNotifyCompanion = userData.companions && userData.companions.some(c => c.notify_daily_symptoms);
-                let modalBodyHTML = `<div class="flex justify-between items-center mb-4"><button id="delete-log-btn" class="text-red-500 hover:text-red-700 text-sm font-semibold ${Object.keys(currentLog).length > 0 ? '' : 'invisible'}">حذف علائم</button><h3 class="text-xl font-bold text-center">ثبت علائم</h3><div class="w-16"></div></div><p class="text-center text-gray-500 mb-4 -mt-4">${toPersian(moment(dateKey, 'YYYY-MM-DD').locale('fa').format('dddd jD jMMMM'))}</p><div class="space-y-4">`;
+                let modalBodyHTML = `<div class="flex justify-between items-center mb-4"><button id="delete-log-btn" class="text-red-500 hover:text-red-700 text-sm font-semibold ${Object.keys(currentLog).length > 0 ? '' : 'invisible'}">حذف علائم</button><h3 class="text-xl font-bold text-center">ثبت علائم</h3><div class="w-16"></div></div><p class="text-center text-gray-500 mb-4 -mt-4">${toPersian(moment(dateKey, 'YYYY-MM-DD').locale('fa').format('dddd D MMMM'))}</p><div class="space-y-4">`;
                 for (const categoryKey in LOG_CONFIG) {
                     if (categoryKey === 'moods' && shouldNotifyCompanion) {
                         modalBodyHTML += `<div class="p-3 pt-4 bg-pink-50 rounded-lg border border-pink-200 space-y-4 relative"><span class="absolute top-2 left-3 text-xs text-pink-600 font-semibold">اطلاع‌رسانی به همراه</span>`;
@@ -501,7 +501,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const { currentDate, targetInputId, periodHistory } = datepickerState;
                 const targetInput = document.getElementById(targetInputId);
                 const selectedDate = targetInput.dataset.value ? moment(targetInput.dataset.value, 'YYYY-MM-DD') : null;
-                const monthStart = currentDate.clone().startOf('jMonth');
+                const monthStart = currentDate.clone().startOf('month');
                 const today = moment();
 
                 // *** START: MODIFICATION to create a set of recorded period days ***
@@ -516,10 +516,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 // *** END: MODIFICATION ***
 
-                let html = `<div class="datepicker-header"><button class="p-2 rounded-full hover:bg-gray-100" onclick="window.app.changeDatePickerMonth(-1)">&lt;</button><span class="font-bold">${toPersian(currentDate.locale('fa').format('jMMMM jYYYY'))}</span><button class="p-2 rounded-full hover:bg-gray-100" onclick="window.app.changeDatePickerMonth(1)">&gt;</button></div><div class="grid grid-cols-7 text-center text-xs text-gray-500 mb-2">${['ش','ی','د','س','چ','پ','ج'].map(d=>`<span>${d}</span>`).join('')}</div><div class="datepicker-grid">`;
-                for (let i = 0; i < monthStart.jDay(); i++) html += '<div></div>';
-                for (let i = 1; i <= currentDate.jDaysInMonth(); i++) {
-                    const dayMoment = currentDate.clone().jDate(i);
+                let html = `<div class="datepicker-header"><button class="p-2 rounded-full hover:bg-gray-100" onclick="window.app.changeDatePickerMonth(-1)">&lt;</button><span class="font-bold">${toPersian(currentDate.locale('fa').format('MMMM YYYY'))}</span><button class="p-2 rounded-full hover:bg-gray-100" onclick="window.app.changeDatePickerMonth(1)">&gt;</button></div><div class="grid grid-cols-7 text-center text-xs text-gray-500 mb-2">${['ش','ی','د','س','چ','پ','ج'].map(d=>`<span>${d}</span>`).join('')}</div><div class="datepicker-grid">`;
+                for (let i = 0; i < ((monthStart.day() + 1) % 7); i++) html += '<div></div>';
+                for (let i = 1; i <= currentDate.daysInMonth(); i++) {
+                    const dayMoment = currentDate.clone().date(i);
                     let classes = 'datepicker-day';
                     const isDisabled = dayMoment.isAfter(today, 'day');
                     if (isDisabled) classes += ' disabled';
@@ -541,13 +541,13 @@ document.addEventListener('DOMContentLoaded', function() {
             },
             // *** END: MODIFICATION ***
             changeDatePickerMonth(direction) {
-                datepickerState.currentDate.add(direction, 'jMonth');
+                datepickerState.currentDate.add(direction, 'month');
                 this.renderDatePicker();
             },
             selectDate(dateStr) {
                 const selectedMoment = moment(dateStr, 'YYYY-MM-DD');
                 const targetInput = document.getElementById(datepickerState.targetInputId);
-                targetInput.value = toPersian(selectedMoment.locale('fa').format('jYYYY/jM/jD'));
+                targetInput.value = toPersian(selectedMoment.format('YYYY/MM/DD'));
                 targetInput.dataset.value = selectedMoment.format('YYYY-MM-DD');
                 datepickerModal.classList.remove('visible');
             },
@@ -571,7 +571,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 // *** END: MODIFICATION ***
 
                 const today = moment();
-                dateInput.value = toPersian(today.locale('fa').format('jYYYY/jM/jD'));
+                dateInput.value = toPersian(today.format('YYYY/MM/DD'));
                 dateInput.dataset.value = today.format('YYYY-MM-DD');
                 const lengthSlider = document.getElementById('edit-period-length');
                 const lengthValueSpan = document.getElementById('edit-period-length-value');

--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,7 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/jalali-moment/dist/jalali-moment.browser.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.29.4/min/moment-with-locales.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     
     <script src="config.js?v=1.1"></script>

--- a/public/ui.js
+++ b/public/ui.js
@@ -294,7 +294,7 @@ const renderDashboard = (userData) => {
         editPeriodBtn.classList.remove('animate-heartbeat');
     }
     
-    document.getElementById('next-period-date').textContent = toPersian(moment(expectedNextPeriodStart).locale('fa').format('dddd، jD jMMMM'));
+    document.getElementById('next-period-date').textContent = toPersian(moment(expectedNextPeriodStart).locale('fa').format('dddd، D MMMM'));
     renderCycleChart(finalDayForChart, cycleLength, periodLength, userData, daysDelayed, isFirstRender);
     isFirstRender = false;
     window.app.renderCalendar(moment());
@@ -441,11 +441,11 @@ const renderCycleChart = (dayOfCycle, cycleLength, periodLength, userData, daysD
 
 const renderCalendar = (calendarDate, userData) => {
     if (!userData.user) return;
-    document.getElementById('calendar-month-year').textContent = toPersian(calendarDate.locale('fa').format('jMMMM jYYYY'));
+    document.getElementById('calendar-month-year').textContent = toPersian(calendarDate.locale('fa').format('MMMM YYYY'));
     const calendarGrid = document.getElementById('calendar-grid');
     calendarGrid.innerHTML = '';
-    const monthStart = calendarDate.clone().startOf('jMonth');
-    const monthEnd = calendarDate.clone().endOf('jMonth');
+    const monthStart = calendarDate.clone().startOf('month');
+    const monthEnd = calendarDate.clone().endOf('month');
     
     const recordedPeriodDays = new Set();
     if (userData.period_history) {
@@ -464,7 +464,7 @@ const renderCalendar = (calendarDate, userData) => {
         return recordStart.isSameOrBefore(monthEnd) && recordEnd.isSameOrAfter(monthStart);
     });
     
-    for (let i = 0; i < monthStart.jDay(); i++) { calendarGrid.innerHTML += '<div></div>'; }
+    for (let i = 0; i < ((monthStart.day() + 1) % 7); i++) { calendarGrid.innerHTML += '<div></div>'; }
     
     for (let day = monthStart.clone(); day.isSameOrBefore(monthEnd); day.add(1, 'days')) {
         const dayKey = day.format('YYYY-MM-DD');
@@ -489,7 +489,7 @@ const renderCalendar = (calendarDate, userData) => {
         const hasLog = logData && Object.values(logData).some(v => (Array.isArray(v) && v.length > 0) || (typeof v === 'string' && v) || (typeof v === 'number' && v !== ''));
         const logIndicator = hasLog ? '<div class="log-indicator"></div>' : '';
         const clickHandler = canLog ? `onclick="window.app.openLogModal('${dayKey}')"` : '';
-        calendarGrid.innerHTML += `<div class="${classes}" ${clickHandler}><span>${toPersian(day.jDate())}</span>${logIndicator}</div>`;
+        calendarGrid.innerHTML += `<div class="${classes}" ${clickHandler}><span>${toPersian(day.date())}</span>${logIndicator}</div>`;
     }
 };
 
@@ -621,7 +621,7 @@ const renderAnalysis = (userData, charts) => {
             container.innerHTML = `<p class="text-center text-gray-500 p-4">داده کافی برای رسم نمودار خطی وجود ندارد.</p>`;
             return;
         }
-        charts[canvasId] = new Chart(ctx, { type: 'line', data: { labels: data.labels.map(l => toPersian(moment(l, 'YYYY-MM-DD').format('jM/jD'))), datasets: [{ label, data: data.data, fill: false, borderColor: 'rgba(236, 72, 153, 1)', backgroundColor: 'rgba(236, 72, 153, 0.6)', tension: 0.1 }] }, options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: false, ticks: { callback: (value) => toPersian(value) + ` ${unit}` } }, x: { ticks: { callback: function(val, index) { return index % Math.ceil(data.labels.length / 7) === 0 ? this.getLabelForValue(val) : ''; } } } } } });
+        charts[canvasId] = new Chart(ctx, { type: 'line', data: { labels: data.labels.map(l => toPersian(moment(l, 'YYYY-MM-DD').format('M/D'))), datasets: [{ label, data: data.data, fill: false, borderColor: 'rgba(236, 72, 153, 1)', backgroundColor: 'rgba(236, 72, 153, 0.6)', tension: 0.1 }] }, options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: false, ticks: { callback: (value) => toPersian(value) + ` ${unit}` } }, x: { ticks: { callback: function(val, index) { return index % Math.ceil(data.labels.length / 7) === 0 ? this.getLabelForValue(val) : ''; } } } } } });
     };
 
     const updateAnalysisCharts = (months, phase) => {
@@ -694,7 +694,7 @@ const renderAnalysis = (userData, charts) => {
                                     <span class="absolute text-lg font-bold text-gray-700">${toPersian(cycleLength)} روز</span>
                                 </div>
                                 <div class="text-right text-sm">
-                                    <p class="font-bold text-gray-800">${toPersian(cycleStartDate.format('jD jMMMM'))} - ${toPersian(cycleEndDate.format('jD jMMMM'))}</p>
+                                    <p class="font-bold text-gray-800">${toPersian(cycleStartDate.format('D MMMM'))} - ${toPersian(cycleEndDate.format('D MMMM'))}</p>
                                     <div class="mt-2 space-y-1 text-xs text-gray-600">
                                         <p><span class="inline-block w-2 h-2 rounded-full bg-red-400 ml-2"></span>طول پریود: ${toPersian(periodLength)} روز</p>
                                         <p><span class="inline-block w-2 h-2 rounded-full bg-gray-300 ml-2"></span>طول دوره: ${toPersian(cycleLength)} روز</p>


### PR DESCRIPTION
## Summary
- remove Jalali-specific dependencies and scripts
- standardize all date handling on Gregorian `moment`
- update UI and server logic to parse and format only Gregorian dates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`
- `node --check public/app.js`
- `node --check public/ui.js`


------
https://chatgpt.com/codex/tasks/task_b_68b05524bc7c8331b939eff473510c49